### PR TITLE
Added port parameter for postgresql

### DIFF
--- a/templates/synapse/_homeserver.yaml
+++ b/templates/synapse/_homeserver.yaml
@@ -482,11 +482,14 @@ database:
         user: "{{ .Values.postgresql.username }}"
         password: "{{ .Values.postgresql.password }}"
         database: "{{ .Values.postgresql.database }}"
+        
         {{- if .Values.postgresql.enabled }}
         host: "{{ include "matrix.fullname" . }}-postgresql"
+        port: "5432"
         {{- else }}
         host: "{{ .Values.postgresql.hostname }}"
-        {{- end}}
+        port: "{{ .Values.postgresql.port }}"
+        {{- end }}
         cp_min: 5
         cp_max: 10
 

--- a/values.yaml
+++ b/values.yaml
@@ -148,6 +148,7 @@ postgresql:
 
   # Set this if postgresql.enabled = false
   hostname: ""
+  port: 5432
 
   # Storage to allocate for stable/postgresql
   persistence:


### PR DESCRIPTION
DigitalOcean PostgreSQL instances do not use the standard PostgreSQL port. Since synapse's homeserver.yaml accepts a port parameter, we can just pass it through to the template.