### PR TITLE
Fix riot config.json mount path and server name configuration

### DIFF
--- a/templates/riot/configmap.yaml
+++ b/templates/riot/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   config.json: |
     {
-      "default_server_name": {{ .Values.matrix.serverName | quote }},
+      "default_server_name": {{ .Values.matrix.hostname | quote }},
       "brand": {{ .Values.riot.branding.brand | quote }},
       "branding": {
         {{- if .Values.riot.branding.welcomeBackgroundUrl }}

--- a/templates/riot/deployment.yaml
+++ b/templates/riot/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           volumeMounts:
-            - mountPath: /etc/riot-web/config.json
+            - mountPath: /app/config.json
               name: riot-config
               subPath: config.json
               readOnly: true


### PR DESCRIPTION
Based upon the riot container documentation: https://github.com/vector-im/riot-web#running-from-docker.  The mount point for config.json should be /app/config.json and not /etc/riot-web/config.json.  

I also changed the default_server_name to use the hostname from the values.yaml file instead of the serverName so that riot will point to the server URL even if it is different from the serverName variable.