### PR TITLE
Add TLS to federation port.

### DIFF
--- a/templates/synapse/_homeserver.yaml
+++ b/templates/synapse/_homeserver.yaml
@@ -178,11 +178,14 @@ listeners:
     # will also need to give Synapse a TLS key and certificate: see the TLS section
     # below.)
     #
-    #- port: 8448
-    #  type: http
-    #  tls: true
-    #  resources:
-    #    - names: [client, federation]
+
+    - port: 8448
+      type: http
+      {{- if .Values.matrix.security.enableTls }}
+      tls: true
+      {{- end }}
+      resources:
+        - names: [federation]
 
     # Unsecure HTTP listener: for when matrix traffic passes through a reverse proxy
     # that unwraps TLS.
@@ -197,7 +200,7 @@ listeners:
       bind_addresses: ['0.0.0.0']
 
       resources:
-          - names: [client, federation]
+          - names: [client]
             compress: false
 
         # example additional_resources:
@@ -327,11 +330,16 @@ redaction_retention_period: {{ .Values.matrix.retentionPeriod | default "null" }
 # instance, if using certbot, use `fullchain.pem` as your certificate,
 # not `cert.pem`).
 #
-#tls_certificate_path: "/synapse/conf/example.com.tls.crt"
+{{- if .Values.matrix.security.enableTls }}
+tls_certificate_path: {{ .Values.matrix.security.tlsCertPath }}
+{{- end }}
+
 
 # PEM-encoded private key for TLS
 #
-#tls_private_key_path: "/synapse/conf/example.com.tls.key"
+{{- if .Values.matrix.security.enableTls }}
+tls_private_key_path: {{ .Values.matrix.security.tlsKeyPath }}
+{{- end }}
 
 # Whether to verify TLS server certificates for outbound federation requests.
 #

--- a/templates/synapse/deployment.yaml
+++ b/templates/synapse/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - name: http
               containerPort: 8008
               protocol: TCP
+            - name: federation
+              containerPort: 8448
+              protocol: TCP
           volumeMounts:
             - name: synapse-config
               mountPath: /data
@@ -82,6 +85,9 @@ spec:
               mountPath: /data/uploads
             - name: tmp
               mountPath: /tmp
+            - name: cert-manager-tls
+              mountPath: /data/certs
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /_matrix/static/
@@ -120,3 +126,6 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+        - name: cert-manager-tls
+          secret:
+            secretName: matrix-tls

--- a/templates/synapse/federation-svc.yaml
+++ b/templates/synapse/federation-svc.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.synapse.service.federation.type }}
   ports:
     - port: {{ .Values.synapse.service.federation.port }}
-      targetPort: http
+      targetPort: federation
       protocol: TCP
   selector:
     app.kubernetes.io/name: {{ include "matrix.name" . }}-synapse

--- a/values.yaml
+++ b/values.yaml
@@ -181,6 +181,13 @@ matrix:
     #     acceptKeysInsecurely: false
     #   - serverName: my_other_trusted_server.example.com
 
+    # Enable TLS encrypted port on 8448
+    enableTls: true
+    # Full path to PEM-encoded certificate for TLS
+    tlsCertPath: /data/certs/tls.crt
+    # Full path to PEM-encoded private key for TLS
+    tlsKeyPath: /data/certs/tls.key
+
   logging:
     # Root log level is the default log level for log outputs that do not have more
     # specific settings.


### PR DESCRIPTION
This allows optional binding of the existing matrix-tls certificate to the synapse federation port. 

As we discussed a seperate ingress is likely a far better implementation, However for your review on how I did this as it is relevant for coturn as well.

