### PR TITLE
Rolling update for pvcs

### DIFF
--- a/templates/bridge-discord/deployment.yaml
+++ b/templates/bridge-discord/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
 {{ include "matrix.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.bridges.discord.replicaCount }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "matrix.name" . }}-bridge-discord

--- a/templates/bridge-irc/deployment.yaml
+++ b/templates/bridge-irc/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   {{ include "matrix.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.bridges.irc.replicaCount }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "matrix.name" . }}-bridge-irc

--- a/templates/bridge-whatsapp/deployment.yaml
+++ b/templates/bridge-whatsapp/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
 {{ include "matrix.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.bridges.whatsapp.replicaCount }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "matrix.name" . }}-bridge-whatsapp


### PR DESCRIPTION
Add updateStrategy to ensure kubernetes knows it needs to unschedule the orginal deployment in order to release the ReadWriteOnce PVC on the bridges. Deployments in the chart currently fail when a bridge is in use because the old deployment is never stopped and the new deployment can never mount the ReadWriteOnce PVCs.

Fixes #34 