### PR TITLE
Fix strategy for Deployments

### DIFF
--- a/templates/bridge-discord/deployment.yaml
+++ b/templates/bridge-discord/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "matrix.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.bridges.discord.replicaCount }}
-  updateStrategy:
+  strategy:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0

--- a/templates/bridge-irc/deployment.yaml
+++ b/templates/bridge-irc/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   {{ include "matrix.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.bridges.irc.replicaCount }}
-  updateStrategy:
+  strategy:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0

--- a/templates/bridge-whatsapp/deployment.yaml
+++ b/templates/bridge-whatsapp/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "matrix.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.bridges.whatsapp.replicaCount }}
-  updateStrategy:
+  strategy:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0


### PR DESCRIPTION
I made a silly error on my last PR. `strategy` is for Deployment, `updateStrategy` is for StatefulSet.

Not sure why Kube devs don't make this interface consistent, but that's a conversation for a Matrix chat :)
