### PR TITLE
Support SSL DB connections on IRC Bridge

### DIFF
--- a/templates/bridge-irc/_config.yaml
+++ b/templates/bridge-irc/_config.yaml
@@ -187,8 +187,8 @@ database:
   # For postgres, it must start with postgres://
   # For NeDB, it must start with nedb://. The path is relative to the project directory.
   {{- if .Values.postgresql.enabled }}
-  connectionString: "postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ include "matrix.fullname" . }}-postgresql/{{ .Values.bridges.irc.database }}"
+  connectionString: "postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ include "matrix.fullname" . }}-postgresql/{{ .Values.bridges.irc.database.name }}{{ if .Values.bridges.irc.database.ssl }}?ssl=require&sslmode=allow{{ end }}"
   {{- else }}
-  connectionString: "postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ .Values.postgresql.hostname }}:{{ .Values.postgresql.port }}/{{ .Values.bridges.irc.database }}"
+  connectionString: "postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ .Values.postgresql.hostname }}:{{ .Values.postgresql.port }}/{{ .Values.bridges.irc.database.name }}{{ if .Values.bridges.irc.database.ssl }}?ssl=require&sslmode=allow{{ end }}"
   {{- end }}
 {{- end }}

--- a/templates/bridge-irc/deployment.yaml
+++ b/templates/bridge-irc/deployment.yaml
@@ -75,6 +75,11 @@ spec:
         - name: "bridge-irc"
           image: "{{ .Values.bridges.irc.image.repository }}:{{ .Values.bridges.irc.image.tag }}"
           imagePullPolicy: {{ .Values.bridges.irc.image.pullPolicy }}
+          {{- if not .Values.bridges.irc.database.sslVerify}}
+          env:
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: "0"
+          {{ end }}
           ports:
             - name: bridge
               containerPort: 9006

--- a/values.yaml
+++ b/values.yaml
@@ -461,7 +461,10 @@ bridges:
     # Whether to enable presence (online/offline indicators). If presence is disabled for the homeserver (above), it should be disabled here too
     presence: false
     # Name of Postgres database to store IRC bridge data in, this database will be created if the included Postgres chart is enabled, otherwise you must create it manually
-    database: "matrix_irc"
+    database:
+      name: "matrix_irc"
+      ssl: false
+      sslVerify: true
 
     # Object of IRC servers to connect to, see https://github.com/matrix-org/matrix-appservice-irc/blob/master/config.sample.yaml for config options
     servers:


### PR DESCRIPTION
I've had some 'fun' trying to get the IRC Bridge working with a DO Managed DB. They use SSL and self signed certs.

What this PR adds:

- Support for publicly signed SSL db connectors
- Support for self-signed SSL db connectors

What is not yet supported:

- Mutual TLS auth (this requires client certs and while I know how to do this I don't have the means to test it at the moment, so that will be a later PR.)
