### PR TITLE
Some CoTURN fixes & Prometheus metrics

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.1
+version: 2.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.0
+version: 2.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/synapse/_homeserver.yaml
+++ b/templates/synapse/_homeserver.yaml
@@ -223,6 +223,14 @@ listeners:
     #    module: my_module.CustomRequestHandler
     #    config: {}
 
+{{- if .Values.synapse.metrics.enabled }}
+  - type: metrics
+    port: {{ .Values.synapse.metrics.port }}
+    bind_addresses: ['0.0.0.0']
+
+    resources:
+      - names: [metrics]
+{{- end }}
   # Turn on the twisted ssh manhole service on localhost on the given
   # port.
   #
@@ -1165,7 +1173,10 @@ auto_join_rooms:
 
 # Enable collection and rendering of performance metrics
 #
-#enable_metrics: false
+
+{{- if .Values.synapse.metrics.enabled }}
+enable_metrics: true
+{{- end }}
 
 # Enable sentry integration
 # NOTE: While attempts are made to ensure that the logs don't contain

--- a/templates/synapse/_homeserver.yaml
+++ b/templates/synapse/_homeserver.yaml
@@ -856,15 +856,25 @@ max_spider_size: {{ .Values.matrix.urlPreviews.rules.maxSize }}
 #
 #recaptcha_siteverify_api: "https://www.recaptcha.net/recaptcha/api/siteverify"
 
+{{- if .Values.coturn.enabled -}}
 
-{{- if not (empty .Values.coturn.uris) }}
 ## TURN ##
 
 # The public URIs of the TURN server to give to clients
 
+# Let the user specify coturn URIs explicitly
+{{- if not (empty .Values.coturn.uris) }}
+turn_uris:
+    {{- range .Values.coturn.uris }}
+    - {{ . }}
+    {{- end }}
+{{- else }}
+
+# Default to using the matrix hostname as
 turn_uris:
   - "turn:{{ include "matrix.hostname" . }}?transport=udp"
 
+{{- end }}
 # The shared secret used to compute passwords for the TURN server
 
 turn_shared_secret: {{ include "matrix.coturn.sharedSecret" . }}

--- a/templates/synapse/deployment.yaml
+++ b/templates/synapse/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       annotations:
         # re-roll deployment on homeserver.yaml change
         checksum/synapse-config: {{ include (print $.Template.BasePath "/synapse/configmap.yaml") . | sha256sum }}
+{{- if and (eq .Values.synapse.metrics.enabled true) (eq .Values.synapse.metrics.annotations true) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/_synapse/metrics"
+        prometheus.io/port: {{ .Values.synapse.metrics.port | quote }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ include "matrix.name" . }}-synapse
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -68,6 +73,11 @@ spec:
             - name: http
               containerPort: 8008
               protocol: TCP
+            {{- if .Values.synapse.metrics.enabled }}
+            - name: prometheus-http
+              containerPort: {{ .Values.synapse.metrics.port }}
+              protocol: TCP
+            {{- end }}
           volumeMounts:
             - name: synapse-config
               mountPath: /data

--- a/values.yaml
+++ b/values.yaml
@@ -300,6 +300,16 @@ synapse:
       timeoutSeconds: 5
       periodSeconds: 10
 
+  # Prometheus metrics for Synapse
+  # https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.md
+  metrics:
+    # Whether Synapse should capture metrics on an additional endpoint
+    enabled: true
+    # Port to listen on for metrics scraping
+    port: 9092
+    annotations: true
+
+
 # Element (formerly Riot Web) client configuration
 riot:
   # Set to false to disable a deployment of Element. Users will still be able to connect via any other instances of Element (such as https://app.element.io), Element Desktop, or any other Matrix clients


### PR DESCRIPTION
 In the `values.yaml` file, it appears that you can manually set TURN URIs to be set in the Matrix homeserver configuration. See below:
https://github.com/dacruz21/matrix-chart/blob/55dfb5b5c8f386bb3541aa27492e9cd07f611430/values.yaml#L381-L386

However, these URIs do not actually get templated into the `homeserver.yaml` file - rather, a TURN URI is generated based off of the `matrix.hostname` helper.

https://github.com/dacruz21/matrix-chart/blob/55dfb5b5c8f386bb3541aa27492e9cd07f611430/templates/synapse/_homeserver.yaml#L860-L883

The surrounding logic of the TURN configuration block looks like it should take URIs if they are listed in the `values.yaml` file. 

---
More context for anyone getting here via Google: 

I am using DigitalOcean Kubernetes Service (DOKS). My Synapse ingress is on a shared nginx-ingress deployment with a DO LoadBalancer but my CoTURN servers are running as DaemonSets with ClusterIP. My DNS is configured so that I have multiple A records for `turn.matrix.mydomain.tld` that point to each node in my cluster. With the way that this chart works as of this present time the defaulting to `turn:matrix.mydomain.tld?transport=udp` does not work because my turn servers are not there and cannot be there - not any particularly sane ways to make nginx-ingress handle this traffic.

Furthermore, neither Element nor Synapse seem to care about SRV records for TURN servers or, if they do, I have not found the secret to making that work. My configuration seems to work if I manually adjust the homeserver and CoTURN configmaps, so with these changes this use case should be solvable with the `values.yaml` file only.