### PR TITLE
Improved prometheus metrics & tags for selectors

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.6.2
+version: 2.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,36 +40,44 @@ helm.sh/chart: {{ include "matrix.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app: matrix
+app.kubernetes.io/name: "matrix"
 {{- end -}}
-
-
+# TODO: Include labels from values
 {{/*
 Synapse specific labels
 */}}
 {{- define "matrix.synapse.labels" -}}
-component: synapse
+{{- range $key, $val := .Values.synapse.labels -}}
+{{ $key }}: {{ $val }}
+{{- end }}
 {{- end -}}
 
 {{/*
 Element specific labels
 */}}
+#TOOO: Change riot to element
 {{- define "matrix.element.labels" -}}
-component: element
+{{- range $key, $val := .Values.riot.labels }}
+{{ $key }}: {{ $val }}
+{{- end }}
 {{- end -}}
 
 {{/*
 Coturn specific labels
 */}}
 {{- define "matrix.coturn.labels" -}}
-component: coturn
+{{- range $key, $val := .Values.coturn.labels -}}
+{{ $key }}: {{ $val }}
+{{- end }}
 {{- end -}}
 
 {{/*
 Mail specific labels
 */}}
 {{- define "matrix.mail.labels" -}}
-component: mail
+{{- range $key, $val := .Values.matrix.labels -}}
+{{ $key }}: {{ $val }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,6 +40,36 @@ helm.sh/chart: {{ include "matrix.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: matrix
+{{- end -}}
+
+
+{{/*
+Synapse specific labels
+*/}}
+{{- define "matrix.synapse.labels" -}}
+component: synapse
+{{- end -}}
+
+{{/*
+Element specific labels
+*/}}
+{{- define "matrix.element.labels" -}}
+component: element
+{{- end -}}
+
+{{/*
+Coturn specific labels
+*/}}
+{{- define "matrix.coturn.labels" -}}
+component: coturn
+{{- end -}}
+
+{{/*
+Mail specific labels
+*/}}
+{{- define "matrix.mail.labels" -}}
+component: mail
 {{- end -}}
 
 {{/*

--- a/templates/coturn/configmap.yaml
+++ b/templates/coturn/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-coturn-config
   labels:
 {{ include "matrix.labels" . | nindent 4}}
+{{ include "matrix.coturn.labels" . | indent 4}}
 data:
   turnserver.conf: |
     use-auth-secret

--- a/templates/coturn/deployment.yaml
+++ b/templates/coturn/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-coturn
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.coturn.labels" . | indent 4}}
 spec:
   {{- if eq .Values.coturn.kind "Deployment" }}
   replicas: {{ .Values.coturn.replicaCount }}

--- a/templates/coturn/network-policy.yaml
+++ b/templates/coturn/network-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-coturn
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.coturn.labels" . | indent 4}}
 spec:
   podSelector:
     matchLabels:

--- a/templates/coturn/service.yaml
+++ b/templates/coturn/service.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-coturn
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.coturn.labels" . | indent 4}}
 spec:
   type: {{ .Values.coturn.service.type }}
   ports:

--- a/templates/exim/deployment.yaml
+++ b/templates/exim/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-exim-relay
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.mail.labels" . | indent 4}}
 spec:
   replicas: {{ .Values.mail.relay.replicaCount }}
   selector:

--- a/templates/exim/network-policy.yaml
+++ b/templates/exim/network-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-exim-relay
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.mail.labels" . | indent 4}}
 spec:
   podSelector:
     matchLabels:

--- a/templates/exim/service.yaml
+++ b/templates/exim/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-exim-relay
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.mail.labels" . | indent 4}}
 spec:
   type: {{ .Values.mail.relay.service.type }}
   ports:

--- a/templates/riot/configmap.yaml
+++ b/templates/riot/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-riot-config
   labels:
 {{ include "matrix.labels" . | nindent 4}}
+{{ include "matrix.element.labels" . | indent 4}}
 data:
   config.json: |
     {

--- a/templates/riot/deployment.yaml
+++ b/templates/riot/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-riot
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.element.labels" . | indent 4}}
 spec:
   replicas: {{ .Values.riot.replicaCount }}
   selector:

--- a/templates/riot/network-policy.yaml
+++ b/templates/riot/network-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-riot
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.element.labels" . | indent 4}}
 spec:
   podSelector:
     matchLabels:

--- a/templates/riot/service.yaml
+++ b/templates/riot/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-riot
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.element.labels" . | indent 4}}
 spec:
   type: {{ .Values.riot.service.type }}
   ports:

--- a/templates/synapse/configmap.yaml
+++ b/templates/synapse/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-synapse-config
   labels:
 {{ include "matrix.labels" . | nindent 4}}
+{{ include "matrix.synapse.labels" . | nindent 4}}
 data:
   homeserver.yaml: |
     {{ include "homeserver.yaml" . | nindent 4 }}

--- a/templates/synapse/deployment.yaml
+++ b/templates/synapse/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               containerPort: 8008
               protocol: TCP
             {{- if .Values.synapse.metrics.enabled }}
-            - name: prometheus-http
+            - name: metrics
               containerPort: {{ .Values.synapse.metrics.port }}
               protocol: TCP
             {{- end }}

--- a/templates/synapse/deployment.yaml
+++ b/templates/synapse/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-synapse
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.synapse.labels" . | indent 4}}
 spec:
   replicas: {{ .Values.synapse.replicaCount }}
   selector:
@@ -17,11 +18,6 @@ spec:
       annotations:
         # re-roll deployment on homeserver.yaml change
         checksum/synapse-config: {{ include (print $.Template.BasePath "/synapse/configmap.yaml") . | sha256sum }}
-{{- if and (eq .Values.synapse.metrics.enabled true) (eq .Values.synapse.metrics.annotations true) }}
-        prometheus.io/scrape: "true"
-        prometheus.io/path: "/_synapse/metrics"
-        prometheus.io/port: {{ .Values.synapse.metrics.port | quote }}
-{{- end }}
       labels:
         app.kubernetes.io/name: {{ include "matrix.name" . }}-synapse
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/synapse/federation-svc.yaml
+++ b/templates/synapse/federation-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-synapse-federation
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.synapse.labels" . | indent 4}}
 spec:
   type: {{ .Values.synapse.service.federation.type }}
   ports:

--- a/templates/synapse/media-pvc.yaml
+++ b/templates/synapse/media-pvc.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-media-store
   labels:
 {{ include "matrix.labels" . | indent 4}}
+{{ include "matrix.synapse.labels" . | indent 4}}
 spec:
   {{- if .Values.volumes.media.storageClass }}
   storageClassName: {{ .Values.volumes.media.storageClass }}

--- a/templates/synapse/network-policy.yaml
+++ b/templates/synapse/network-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-synapse
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.synapse.labels" . | indent 4}}
 spec:
   podSelector:
     matchLabels:

--- a/templates/synapse/service.yaml
+++ b/templates/synapse/service.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "matrix.fullname" . }}-synapse
   labels:
 {{ include "matrix.labels" . | indent 4 }}
+{{ include "matrix.synapse.labels" . | indent 4}}
+  annotations:
+{{- if and (eq .Values.synapse.metrics.enabled true) (eq .Values.synapse.metrics.annotations true) }}
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/_synapse/metrics"
+    prometheus.io/port: {{ .Values.synapse.metrics.port | quote }}
+{{- end }}
 spec:
   type: {{ .Values.synapse.service.type }}
   ports:

--- a/templates/synapse/service.yaml
+++ b/templates/synapse/service.yaml
@@ -11,6 +11,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.synapse.metrics.enabled }}
+    - port: {{ .Values.synapse.metrics.port }}
+      targetPort: prometheus-http
+      protocol: TCP
+      name: prometheus-http
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "matrix.name" . }}-synapse
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/synapse/service.yaml
+++ b/templates/synapse/service.yaml
@@ -20,9 +20,9 @@ spec:
       name: http
     {{- if .Values.synapse.metrics.enabled }}
     - port: {{ .Values.synapse.metrics.port }}
-      targetPort: prometheus-http
+      targetPort: metrics
       protocol: TCP
-      name: prometheus-http
+      name: metrics
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "matrix.name" . }}-synapse

--- a/templates/synapse/signing-key-pvc.yaml
+++ b/templates/synapse/signing-key-pvc.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "matrix.fullname" . }}-signing-key
   labels:
 {{ include "matrix.labels" . | indent 4}}
+{{ include "matrix.synapse.labels" . | indent 4}}
 spec:
   {{- if .Values.volumes.signingKey.storageClass }}
   storageClassName: {{ .Values.volumes.signingKey.storageClass }}

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,10 @@ matrix:
   # domain name at the end of every user's username
   serverName: "example.com"
 
+  # Global labels to append to all deployments / services etc.
+  labels:
+    app: "matrix"
+
   # Enable anonymous telemetry to matrix.org
   telemetry: false
 
@@ -300,6 +304,10 @@ synapse:
       timeoutSeconds: 5
       periodSeconds: 10
 
+  # Labels to be appended to all Synapse resources
+  labels:
+    component: synapse
+  
   # Prometheus metrics for Synapse
   # https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.md
   metrics:
@@ -383,6 +391,10 @@ riot:
     startup: {}
     liveness: {}
 
+  # Element specific labels
+  labels:
+    component: element
+
 # Settings for Coturn TURN relay, used for routing voice calls
 coturn:
   # Set to false to disable the included deployment of Coturn
@@ -432,6 +444,10 @@ coturn:
   replicaCount: 1
   resources: {}
 
+  # Coturn specific labels
+  labels:
+    component: coturn
+
 # Settings for email notifications
 mail:
   # Set to false to disable all email notifications
@@ -460,6 +476,10 @@ mail:
       readiness: {}
       startup: {}
       liveness: {}
+  
+  # Mail relay specific labels
+  labels:
+    component: mail
 
   # External mail server
   external:

--- a/values.yaml
+++ b/values.yaml
@@ -14,10 +14,6 @@ matrix:
   # domain name at the end of every user's username
   serverName: "example.com"
 
-  # Global labels to append to all deployments / services etc.
-  labels:
-    app: "matrix"
-
   # Enable anonymous telemetry to matrix.org
   telemetry: false
 


### PR DESCRIPTION
Moved metrics from pod level to service level and added tags. Classic style scrape annotations still work and now you can use Prometheus Operator `ServiceMonitor` resources to monitor Synapse.

Pairs well with [Grafana Dashboards - Synapse Dashboard](https://grafana.com/grafana/dashboards/10046)