### PR TITLE
template bridge-whatsapp/configmap.yaml relaybot.invites must be …

### DIFF
--- a/templates/bridge-whatsapp/configmap.yaml
+++ b/templates/bridge-whatsapp/configmap.yaml
@@ -151,7 +151,14 @@ data:
         # the command prefix completely like in user management rooms is not possible.
         management: {{ .Values.bridges.whatsapp.relaybot.management }}
         # List of users to invite to all created rooms that include the relaybot.
-        invites: {{ .Values.bridges.whatsapp.relaybot.invites }}
+        {{- if .Values.bridges.whatsapp.relaybot.invites }}
+        invites:{{- if .Values.bridges.whatsapp.relaybot.invites }}
+        {{- range initial .Values.bridges.whatsapp.relaybot.invites }}
+        - {{ . | quote }}
+        {{- end }}
+        - {{ last .Values.bridges.whatsapp.relaybot.invites | quote }}
+        {{- end }}
+        {{- end }}
         # The formats to use when sending messages to WhatsApp via the relaybot.
         message_formats:
           m.text: "<b>{{ "{{ .Sender.Displayname }}" }}</b>: {{ "{{ .Message }}" }}"

--- a/templates/bridge-whatsapp/deployment.yaml
+++ b/templates/bridge-whatsapp/deployment.yaml
@@ -56,17 +56,17 @@ spec:
           image: "{{ .Values.bridges.whatsapp.image.repository }}:{{ .Values.bridges.whatsapp.image.tag }}"
           imagePullPolicy: {{ .Values.bridges.whatsapp.image.pullPolicy }}
           command: ["sh"]
-          args: ["-c", "cp /load/config.yaml /data/config.yaml"]
+          args: ["-c", "cp /load/config.yaml /data/config.yaml; touch /bridges/whatsapp.yaml; chown 1000:1000 /data/config.yaml /bridges/whatsapp.yaml"]
           volumeMounts:
             - name: data
               mountPath: /data
             - name: config
               mountPath: /load
               readOnly: true
+            - name: bridges
+              mountPath: /bridges
           securityContext:
-            capabilities:
-              drop:
-                - ALL
+            runAsUser: 0
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: "generate-config"


### PR DESCRIPTION
template bridge-whatsapp/configmap.yaml relaybot.invites must be array quote

https://github.com/tulir/mautrix-whatsapp/blob/v0.1.4/example-config.yaml#L228-L229

Example:

```yaml
invites:
    - "pep:example.local"
    - "guardiola:example.local"
```
