### PR TITLE
On Ubuntu CDK Kubernetes whit Cinder(openstack) Permission problem

### DIFF
--- a/templates/bridge-whatsapp/deployment.yaml
+++ b/templates/bridge-whatsapp/deployment.yaml
@@ -56,17 +56,17 @@ spec:
           image: "{{ .Values.bridges.whatsapp.image.repository }}:{{ .Values.bridges.whatsapp.image.tag }}"
           imagePullPolicy: {{ .Values.bridges.whatsapp.image.pullPolicy }}
           command: ["sh"]
-          args: ["-c", "cp /load/config.yaml /data/config.yaml"]
+          args: ["-c", "cp /load/config.yaml /data/config.yaml; touch /bridges/whatsapp.yaml; chown 1000:1000 /data/config.yaml /bridges/whatsapp.yaml"]
           volumeMounts:
             - name: data
               mountPath: /data
             - name: config
               mountPath: /load
               readOnly: true
+            - name: bridges
+              mountPath: /bridges
           securityContext:
-            capabilities:
-              drop:
-                - ALL
+            runAsUser: 0
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: "generate-config"


### PR DESCRIPTION
On Ubuntu CDK Kubernetes whit Cinder(openstack)  we need to set permision before to user 1000:1000

Fix permision on load-config init container this apply on Kubernetes  CDK whit Cinder-csi...