### PR TITLE
Fix launch of matrix-bridge-irc.

### DIFF
--- a/templates/bridge-irc/deployment.yaml
+++ b/templates/bridge-irc/deployment.yaml
@@ -74,6 +74,8 @@ spec:
       containers:
         - name: "bridge-irc"
           image: "{{ .Values.bridges.irc.image.repository }}:{{ .Values.bridges.irc.image.tag }}"
+          command: "node"
+          args: [ "app.js", "-c", "/data/config.yaml", "-f", "/data/appservice-registration-irc.yaml" ]
           imagePullPolicy: {{ .Values.bridges.irc.image.pullPolicy }}
           {{- if not .Values.bridges.irc.databaseSslVerify }}
           env:


### PR DESCRIPTION
This resolves the issue I experienced in https://github.com/dacruz21/matrix-chart/issues/44. The latest versions of the matrixdotorg/matrix-appservice-irc container image launches the node.js process with incompatible defaults as below. This PR will allow the chart to work out of the box with the default values.:

Container defaults:
```
exec node app.js -c /data/config.yaml -p 9995 -f /data/appservice-registration-irc.yaml -u http://localhost:9995
```

This PR changes the execution to:

```
          command: "node"
          args: [ "app.js", "-c", "/data/config.yaml", "-f", "/data/appservice-registration-irc.yaml" ]
```