### PR TITLE
use new kubernetes storage bucket

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 8.0.0
-digest: sha256:54b8dbbf92f98a307a15de995f41897aa3ea3f3252b6f594d058530755b3dfa8
-generated: "2020-03-30T22:24:34.251333366-07:00"
+digest: sha256:275b46bd8fa7b699ad1db6bdcb404cd66500c18093e667f3486804ed1c70ac1e
+generated: "2021-03-06T15:12:57.213917-05:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -32,5 +32,5 @@ maintainers:
 dependencies:
   - name: postgresql
     version: 8.0.0
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: postgresql.enabled


### PR DESCRIPTION
Hey - the storage bucket currently being used is deprecated and has been upgraded to the new repo, see [this update](https://helm.sh/blog/new-location-stable-incubator-charts/)