### PR TITLE
Fix various issues

### DIFF
--- a/templates/synapse/_homeserver.yaml
+++ b/templates/synapse/_homeserver.yaml
@@ -1820,7 +1820,7 @@ password_config:
 email:
   enable_notifs: {{ .Values.mail.enabled }}
   notif_from: {{ .Values.mail.from }}
-  {{- if .Values.mail.relay.enabled }}
+  {{- if eq .Values.mail.relay.enabled true }}
   smtp_host: {{ include "matrix.fullname" . }}-exim-relay
   smtp_port: {{ .Values.mail.relay.service.port }}
   {{- else }}

--- a/templates/synapse/_homeserver.yaml
+++ b/templates/synapse/_homeserver.yaml
@@ -832,7 +832,7 @@ url_preview_ip_range_whitelist:
 
 {{- if .Values.matrix.urlPreviews.rules.url.blacklist }}
 url_preview_url_blacklist:
-{{ include .Values.matrix.urlPreviews.rules.url.blacklist . | nindent 2 }}
+{{ toYaml .Values.matrix.urlPreviews.rules.url.blacklist | nindent 2 }}
 {{- end }}
 
 # The largest allowed URL preview spidering size in bytes

--- a/templates/synapse/configmap.yaml
+++ b/templates/synapse/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   homeserver.yaml: |
     {{ include "homeserver.yaml" . | nindent 4 }}
-  {{ .Values.matrix.serverName }}.log.config: |
+  "{{ .Values.matrix.serverName }}.log.config": |
     version: 1
 
     formatters:


### PR DESCRIPTION
(1) Fix improper url blacklist inclusion
Fixes the following error generated when multiple blacklist items are in the map:

Error: INSTALLATION FAILED: template: matrix/templates/synapse/deployment.yaml:20:36: executing "matrix/templates/synapse/deployment.yaml" at <include (print $.Template.BasePath "/synapse/configmap.yaml") .>: error calling include: template: matrix/templates/synapse/configmap.yaml:10:7: executing "matrix/templates/synapse/configmap.yaml" at <include "homeserver.yaml" .>: error calling include: template: matrix/templates/synapse/_homeserver.yaml:835:18: executing "homeserver.yaml" at <.Values.matrix.urlPreviews.rules.url.blacklist>: wrong type for value; expected string; got []interface {}

(2) Fix bad exim relay settings
Bad logic results in 'relay.enabled' always being evaluated to true
